### PR TITLE
Add multiple discord role functionality

### DIFF
--- a/DiscordVehicleWhitelist/License.md
+++ b/DiscordVehicleWhitelist/License.md
@@ -1,0 +1,23 @@
+## Terms of Use
+
+(Below the term "product" is used to describe the script / modification)
+
+This product is freeware and is not to be exploited for personal, financial or commercial gain. This product is provided without any form of warranty.
+Therefore, responsibility for any damages caused by this product or its misuse rest solely with the user, as the author(s) will accept no liability.
+
+- This copy of terms must remain in its original state and must not be modified in anyway
+
+- These terms must be alongside the product at all times
+
+- Do not re-release with out permission (just ask for permission)
+
+- Do not redistribute to any other sites. This product is only to be published on verified sites by FAXES
+
+- Editing / abusing these terms will result in action
+
+- Do not take credit for product. Removing credits from inside the products file(s) is prohibited
+
+### Summery
+So basically you can edit anything with the product (except the terms), but you can not release the product nor release the edited version without written permission from FAXES. 
+
+![alt text](https://faxes.zone/TOSlogos/FAXES%20ToUSML.png "FAXES ToU Icon")

--- a/DiscordVehicleWhitelist/README.md
+++ b/DiscordVehicleWhitelist/README.md
@@ -1,0 +1,26 @@
+# DiscordVehicleWhitelist
+A Discord vehicle white-list script for FiveM
+**Discord Vehicle Whitelist- By FAXES**
+
+## [Support Discord](https://faxes.zone/discord)
+
+**About**
+Hello all. For my 40th release here on the forums, I thought let's make it something cool(ish)? So I introduce to you a Discord (role) Vehicle Whitelist! This is a nice simple script, easy to set up (for people that can read). It allows you to guess? Make a vehicle whitelist based on a users role in Discord. This has been requested a few times so here she is, for you!
+
+**Features**
+- Vehicle whitelist, based on Discord roles
+- Easy config (just read...)
+- Checks for role updates every player respawn
+
+**Requirements**
+@IllusiveTea's [Discord Role For Permission Script](https://forum.fivem.net/t/discord-roles-for-permissions-im-creative-i-know/233805) - **Ensure that it is the one from the master branch!**
+
+**Installation**
+https://docs.faxes.zone/docs/discord-vehicle-whitelist-setup/
+
+<hr>
+
+**Credits**
+@IllusiveTea for his resource
+
+If you have any issues or comments please put them below. :newspaper:

--- a/DiscordVehicleWhitelist/client.lua
+++ b/DiscordVehicleWhitelist/client.lua
@@ -1,0 +1,62 @@
+------------------------------------------------
+--- Discord Vehicle Whitelist, Made by FAXES ---
+------------- Modified by Clink123 -------------
+------------------------------------------------
+
+--- Code ---
+
+local lastVeh = nil
+
+RegisterNetEvent("FaxDisVeh:CheckPermission:Return")
+AddEventHandler("FaxDisVeh:CheckPermission:Return", function(havePerms, error)
+    if error then
+        print("^1No Discord identifier was found! ^rPermissions set to false. See this link for a debugging process - docs.faxes.zone/docs/debugging-discord")
+    end
+    if havePerms then
+    else
+		local ped = PlayerPedId()
+		local veh = nil
+		if IsPedInAnyVehicle(ped, false) then
+			veh = GetVehiclePedIsUsing(ped)
+		else
+			veh = GetVehiclePedIsTryingToEnter(ped)
+		end
+		if veh and DoesEntityExist(veh) then
+			ShowInfo("~r~Restricted vehicle model.")
+			DeleteEntity(veh)
+			ClearPedTasksImmediately(ped)
+		end
+    end
+end)
+
+Citizen.CreateThread(function()
+    while true do			
+		Citizen.Wait(500)
+		local src = source
+		local ped = PlayerPedId()
+		local veh = nil
+		if IsPedInAnyVehicle(ped, false) then
+			veh = GetVehiclePedIsUsing(ped)
+			if veh and DoesEntityExist(veh) then
+				local model = GetEntityModel(veh)
+				local driver = GetPedInVehicleSeat(veh, -1)
+				if driver == ped then
+					if (lastVeh ~= veh) then
+						TriggerServerEvent("FaxDisVeh:CheckPermission", model)
+						lastVeh = veh
+					end
+				end
+			end
+		end
+    end
+end)
+
+--- Functions ---
+function ShowInfo(text)
+	BeginTextCommandThefeedPost("STRING")
+	AddTextComponentSubstringPlayerName(text)
+	EndTextCommandThefeedPostTicker(false, false)
+end
+function DeleteE(entity)
+	Citizen.InvokeNative(0xAE3CBE5BF394C9C9, Citizen.PointerValueIntInitialized(entity))
+end

--- a/DiscordVehicleWhitelist/fxmanifest.lua
+++ b/DiscordVehicleWhitelist/fxmanifest.lua
@@ -1,0 +1,10 @@
+----------------------------------------
+--- Discord Whitelist, Made by FAXES ---
+----------------------------------------
+
+fx_version 'bodacious'
+game 'gta5'
+author 'FAXES'
+
+server_script 'server.lua'
+client_script 'client.lua'

--- a/DiscordVehicleWhitelist/server.lua
+++ b/DiscordVehicleWhitelist/server.lua
@@ -1,0 +1,67 @@
+------------------------------------------------
+--- Discord Vehicle Whitelist, Made by FAXES ---
+------------- Modified by Clink123 -------------
+------------------------------------------------
+
+--- Config ---
+
+local RoleVehicleDictionary = {
+    ['736824407598694432'] = {"charger", "crownvic", "tahoe13", "tahoe"},
+	['736415956091404362'] = {"czr1", "c8", "1980BroncoLifted", "2008F350", "2010Ram3500", "2010Silverado1500", "2015GMCYukonDenali", "KenworthT440", "Ram3500Flatbed", "stormtr", "flatbedm2", "cxt1", "yacht2", "gruppe1", "gruppe2", "gruppe3"},
+    ['738995097911427113'] = {"8q400","a220","a319","tu154m","saab2000","md80","lcf","lcfloader","l1011","il76","il62m","ha420","fokker100","emb190","emb175","emb145","emb120","emb100","e190e2","dc30f","dc10","beluga","bac","b727c","b727","avashut","an225","atr72","a380","a350","a343","a340","a333","a321neo","a320","788","779x","773er","757","748f","748","747sp","747","739","707","208"},
+}
+
+--- Code ---
+
+RegisterServerEvent("FaxDisVeh:CheckPermission")
+AddEventHandler("FaxDisVeh:CheckPermission", function(model)
+    local src = source
+    local passAuth = false
+	local delete = false
+
+    for k, v in ipairs(GetPlayerIdentifiers(src)) do
+        if string.sub(v, 1, string.len("discord:")) == "discord:" then
+            identifierDiscord = v
+        end
+    end
+
+    if identifierDiscord then
+        usersRoles = exports.discord_perms:GetRoles(src)
+        local function has_value(table, val)
+            if table then
+                for index, value in ipairs(table) do
+                    if value == val then
+                        return true
+                    end
+                end
+            end
+            return false
+        end
+		local function has_valueVeh(table, val)
+            if table then
+                for index, value in ipairs(table) do
+                    if GetHashKey(value) == val then
+                        return true
+                    end
+                end
+            end
+            return false
+        end
+        for role, vehicles in pairs(RoleVehicleDictionary) do 
+            if not has_value(usersRoles, role) then
+				if has_valueVeh(vehicles, model) then
+					delete = true;
+				end
+            end
+            if next(RoleVehicleDictionary, role) == nil then
+                if delete == true then
+                    TriggerClientEvent("FaxDisVeh:CheckPermission:Return", src, false, false)
+                else
+                    TriggerClientEvent("FaxDisVeh:CheckPermission:Return", src, true, false)
+                end
+            end
+        end
+    else
+        TriggerClientEvent("FaxDisVeh:CheckPermission:Return", src, false, true)
+    end
+end)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # DiscordVehicleWhitelist
 A Discord vehicle white-list script for FiveM
-**Discord Vehicle Whitelist- By FAXES**
+**Discord Vehicle Whitelist- By FAXES Modified by Clink123**
 
 ## [Support Discord](https://faxes.zone/discord)
-
-**About**
-Hello all. For my 40th release here on the forums, I thought let's make it something cool(ish)? So I introduce to you a Discord (role) Vehicle Whitelist! This is a nice simple script, easy to set up (for people that can read). It allows you to guess? Make a vehicle whitelist based on a users role in Discord. This has been requested a few times so here she is, for you!
 
 **Features**
 - Vehicle whitelist, based on Discord roles
@@ -16,11 +13,12 @@ Hello all. For my 40th release here on the forums, I thought let's make it somet
 @IllusiveTea's [Discord Role For Permission Script](https://forum.fivem.net/t/discord-roles-for-permissions-im-creative-i-know/233805) - **Ensure that it is the one from the master branch!**
 
 **Installation**
-https://docs.faxes.zone/docs/discord-vehicle-whitelist-setup/
+Add your vehicles and roles in server.lua. Drag and drop the resource. Roles go in [], vehicles in {}. Example is in the file.
 
 <hr>
 
 **Credits**
 @IllusiveTea for his resource
+FAXES for the original script.
 
 If you have any issues or comments please put them below. :newspaper:


### PR DESCRIPTION
This edition enables the user to define a dictionary of discord role IDs, so basically a list of discord IDs each with a list of associated vehicles to blacklist.